### PR TITLE
Complete scroll to reviews feature

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -11,6 +11,7 @@ class App extends React.Component {
     this.state = {
       product: {}
     }
+    this.reviewsRef = React.createRef();
   }
 
 
@@ -23,15 +24,19 @@ class App extends React.Component {
       })
   }
 
+  handleScrollToReviews(event) {
+    window.scrollTo(0, this.reviewsRef.current.offsetTop);
+  }
+
 
   render() {
     if (JSON.stringify(this.state.product) !=='{}') {
       return (
         <div className='container'>
-          <Overview product={this.state.product} />
+          <Overview product={this.state.product} handleScrollToReviews={this.handleScrollToReviews.bind(this)} />
           {/* <RelatedItems product={this.state.product}/> */}
           <QA product={this.state.product}/>
-          <Reviews product={this.state.product}/>
+          <Reviews product={this.state.product} scrollToReviews={this.reviewsRef}/>
         </div>
       )
     } else {

--- a/client/src/components/overview/Overview.jsx
+++ b/client/src/components/overview/Overview.jsx
@@ -61,7 +61,7 @@ class Overview extends React.Component {
     return (
       <div>
         <h2>This is for Overview</h2>
-        <RatingInfo rating={this.state.rating} />
+        {(this.state.rating !== 0) && <RatingInfo rating={this.state.rating} handleScrollToReviews={this.props.handleScrollToReviews} />}
         <ProductInfo name={name} category={category} originalPrice={default_price} salePrice={this.state.salePrice} />
         {this.state.styles.length !== 0 && <StylesSection styles={this.state.styles} selectedStyle={this.state.selectedStyle} selectStyle={this.selectStyle.bind(this)} />}
         <Description slogan={slogan} description={description} />

--- a/client/src/components/overview/Overview.scss
+++ b/client/src/components/overview/Overview.scss
@@ -44,3 +44,8 @@
   text-decoration: line-through;
 }
 
+.read-all-reviews {
+  cursor: pointer;
+  color: rgb(16, 156, 250);
+  text-decoration: underline;
+}

--- a/client/src/components/overview/RatingInfo.jsx
+++ b/client/src/components/overview/RatingInfo.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import Rating from '@material-ui/lab/Rating';
 
-const RatingInfo = ({rating}) => {
+const RatingInfo = ({rating, handleScrollToReviews}) => {
   return (
     <div className='close-flex'>
       <Rating name="half-rating-read" value={rating} precision={0.25} readOnly />
-      <a href="#">Read all reviews</a>
+      <p className='read-all-reviews' onClick={handleScrollToReviews}>Read all reviews</p>
     </div>
   )
 }

--- a/client/src/components/reviews/Reviews.jsx
+++ b/client/src/components/reviews/Reviews.jsx
@@ -24,7 +24,7 @@ class Reviews extends React.Component {
 
   render() {
     return  (
-      <div>
+      <div ref={this.props.scrollToReviews}>
         <h2>This is for Rating and Reviews</h2>
         <p>{JSON.stringify(this.state.views)}</p>
       </div>


### PR DESCRIPTION
For @pyc0422 , in Overview section, I have a feature that when you click to "Read all reviews" links, it will automatically scroll to your Reviews section. Therefore, in App.jsx I created the `handleScrollToReviews` function, but it requires to pass the `ref` to your Reviews components in order to reference to that component for the scroll. So in App.jsx, I passed a props called `scrollToReviews` to the `<Reviews />`, and in Reviews.jsx, in the container `div`, I use that `scrollToReviews` props so it will scroll to that div once the "Read all reviews" link is clicked. Please keep that in mind when you developed further features for the Reviews, please keep the `scrollToReviews` props and `ref` in that position in order for the scroll feature work. Please merge this pull request if you agree. Thank you! 